### PR TITLE
Fix typo on fnmatch return value check

### DIFF
--- a/cmds/idmap/scan.cpp
+++ b/cmds/idmap/scan.cpp
@@ -94,7 +94,7 @@ namespace {
         val = strndup16to8(value.string(), value.size());
 
 	if(val[0]=='+') {
-            return fnmatch(val+1, propBuf, 0) != 0;
+            return fnmatch(val+1, propBuf, 0) == 0;
 	}
 
         return (strcmp(propBuf, val) == 0);


### PR DESCRIPTION
fnmatch returns 0 on match, according to http://man7.org/linux/man-pages/man3/fnmatch.3.html:

```
RETURN VALUE         top

       Zero if string matches pattern, FNM_NOMATCH if there is no match or
       another nonzero value if there is an error.
```