### PR TITLE
Disable AVB check

### DIFF
--- a/core/jni/android_os_VintfObject.cpp
+++ b/core/jni/android_os_VintfObject.cpp
@@ -103,7 +103,7 @@ static jint android_os_VintfObject_verify(JNIEnv* env, jclass, jobjectArray pack
         env->ReleaseStringUTFChars(element, cString);
     }
     std::string error;
-    int32_t status = VintfObject::CheckCompatibility(cPackageInfo, &error);
+    int32_t status = VintfObject::CheckCompatibility(cPackageInfo, &error, vintf::DISABLE_AVB_CHECK);
     if (status)
         LOG(WARNING) << "VintfObject.verify() returns " << status << ": " << error;
     return status;


### PR DESCRIPTION
This avoids the message "There's an internal problem with your
device. Contact your manufacturer for details." on some AVB 1.0
devices.

See https://github.com/phhusson/treble_experimentations/issues/354