### PR TITLE
KeyStore: Block key attestation for Google Play Services

### DIFF
--- a/keystore/java/android/security/KeyStore.java
+++ b/keystore/java/android/security/KeyStore.java
@@ -1124,6 +1124,9 @@ public class KeyStore {
 
     public int attestKey(
             String alias, KeymasterArguments params, KeymasterCertificateChain outChain) {
+        if (mContext.getPackageName().equals("com.google.android.gms")) {
+            return KeymasterDefs.KM_ERROR_UNIMPLEMENTED; // Prevent Google Play Services from using key attestation for SafetyNet
+        }        
         CertificateChainPromise promise = new CertificateChainPromise();
         try {
             mBinder.asBinder().linkToDeath(promise, 0);


### PR DESCRIPTION
All credits should go to @kdrag0n!

Based on his work in [7f7a9b1](https://github.com/ProtonAOSP/android_frameworks_base/commit/7f7a9b19c8293c09dfee12bec75ff17225c6710e).

Original commit description:
> In order to enforce SafetyNet security, Google Play Services is now
> using hardware attestation for ctsProfile validation in all cases, even
> when basic attestation is selected. The SafetyNet API response from GMS
> will report that basic attestation was used, but under the hood,
> hardware attestation is always used regardless of the reported state.
> This results in SafetyNet failing to pass due to TrustZone reporting an
> unlocked bootloader (and a partially invalidated root of trust) in the
> key attestation result.
> 
> We can still take advantage of the fact that this usage of hardware
> attestation is opportunistic - that is, it falls back to basic
> attestation if key attestation fails to run - and prevent GMS from using
> key attestation at the framework level. This causes it to gracefully
> fall back to basic attestation and pass SafetyNet with an unlocked
> bootloader.
> 
> Key attestation is still available for other apps, as there are valid
> uses for it that do not involve SafetyNet.
> 
> The "not implemented" error code from keymaster is used to simulate the
> most realistic failure condition to evade detection, i.e. an old device
> that lacks support for key attestation.
