### PR TITLE
Fix Wakelock issue

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/util/wakelock/WakeLock.java
+++ b/packages/SystemUI/src/com/android/systemui/util/wakelock/WakeLock.java
@@ -109,7 +109,9 @@ public interface WakeLock {
                 } else {
                     mActiveClients.put(why, count - 1);
                 }
-                inner.release();
+                if (inner.isHeld()) {
+                    inner.release();
+                }
             }
 
             /** @see PowerManager.WakeLock#wrap(Runnable) */


### PR DESCRIPTION
Prevent SystemUI crash due to "WakeLock under-locked Doze" (issue #12) by only releasing a wakelock that was not already released