### PR TITLE
Reintroduce button-backlight (and respective inactivity timeout)

### DIFF
--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -61,6 +61,7 @@ import com.android.server.am.BatteryStatsService;
 import com.android.server.display.whitebalance.DisplayWhiteBalanceController;
 import com.android.server.display.whitebalance.DisplayWhiteBalanceFactory;
 import com.android.server.display.whitebalance.DisplayWhiteBalanceSettings;
+import com.android.server.lights.LightsManager;
 import com.android.server.policy.WindowManagerPolicy;
 
 import java.io.PrintWriter;
@@ -153,6 +154,9 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
 
     // Battery stats.
     private final IBatteryStats mBatteryStats;
+
+    // The lights manager.
+    private final LightsManager mLights;
 
     // The sensor manager.
     private final SensorManager mSensorManager;
@@ -412,6 +416,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
         mSettingsObserver = new SettingsObserver(mHandler);
         mCallbacks = callbacks;
         mBatteryStats = BatteryStatsService.getService();
+        mLights = LocalServices.getService(LightsManager.class);
         mSensorManager = sensorManager;
         mWindowManagerPolicy = LocalServices.getService(WindowManagerPolicy.class);
         mBlanker = blanker;
@@ -904,6 +909,12 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
         if (state == Display.STATE_OFF) {
             brightnessState = PowerManager.BRIGHTNESS_OFF_FLOAT;
             mBrightnessReasonTemp.setReason(BrightnessReason.REASON_SCREEN_OFF);
+            mLights.getLight(LightsManager.LIGHT_ID_BUTTONS).setBrightness(brightnessState);
+        }
+
+        // Disable button lights when dozing
+        if (state == Display.STATE_DOZE || state == Display.STATE_DOZE_SUSPEND) {
+            mLights.getLight(LightsManager.LIGHT_ID_BUTTONS).setBrightness(PowerManager.BRIGHTNESS_OFF_FLOAT);
         }
 
         // Always use the VR brightness when in the VR state.


### PR DESCRIPTION
The power manager rewrite from Change I1d7a52e98f0449f76d70bf421f6a7f245957d1d7
completely removed support for control of the button backlights, which makes
all capacitive buttons out there stay dark. The commit message in that change
mentions it hasn't been implemented _yet_, so this fix should be temporary
until upstream does their own implementation

[RC: Updated to 5.0]
[PeterCxy: Updated to R, thanks to LineageOS for forward-porting the commit]

Change-Id: I6094c446e0b8c23f57d30652a3cbd35dee5e821a