### PR TITLE
Replace empty directory env variable by default value

### DIFF
--- a/core/java/android/os/Environment.java
+++ b/core/java/android/os/Environment.java
@@ -1424,9 +1424,13 @@ public class Environment {
         }
     }
 
+    /**
+     * Huawei hi6250 define in init.hi6250.rc ANDROID_STORAGE to "", so check empty string and replace with
+     * default path. Apply change for all directory
+     */
     static File getDirectory(String variableName, String defaultPath) {
         String path = System.getenv(variableName);
-        return path == null ? new File(defaultPath) : new File(path);
+        return ((path == null || path.isEmpty()) ? new File(defaultPath) : new File(path));
     }
 
     @NonNull


### PR DESCRIPTION
I found the cause of the problem. It wasn't the volume name that was empty, just the environment variable that set the start of the external storage volume's default path : env name : ANDROID_STORAGE.

 It is set to "" in an init rc file ( init.hi6250.rc) at the vendor level and the source code tests only null value and not also empty value

Issue describe the bug :
https://github.com/phhusson/treble_experimentations/issues/2386
No default sound and list of system sound (ringtones, alarms, notify) is empty #2386 


-------

Replace empty directory env variable by default value.

Root cause :
Huawei hi6250 define in init.hi6250.rc ANDROID_STORAGE to "", so check empty string and replace with default path.